### PR TITLE
updates packer_fmt hook to format files that fail the check

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ projects using [Packer](https://www.packer.io/).
 
 ## Available Hooks ##
 
-| Hook name         | Description                                             |
-| ----------------- | ------------------------------------------------------- |
-| `packer_validate` | Validate all Packer templates.                          |
-| `packer_fmt`      | Check that Packer HCL templates are properly formatted. |
+| Hook name         | Description                                                                           |
+| ----------------- |---------------------------------------------------------------------------------------|
+| `packer_validate` | Validate all Packer templates.                                                        |
+| `packer_fmt`      | Check that Packer HCL templates are properly formatted, formatting files when needed. |
 
 ## Usage ##
 

--- a/hooks/packer_fmt.sh
+++ b/hooks/packer_fmt.sh
@@ -13,6 +13,7 @@ error=0
 
 for file in "$@"; do
   if ! packer fmt -check "$file"; then
+    packer fmt -write "$file"
     error=1
     echo
     echo "Failed path: $file"


### PR DESCRIPTION
### Description (What does it do?)
fix(packer_fmt): updates packer_fmt hook to format files that fail the check

Incorporates the work of user greenwiki into MITODL fork of this repo. 
